### PR TITLE
Some unused code removals, refactorings and fixes

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -38,7 +38,7 @@
     <div class="wsk-layout">
       <div class="wsk-layout__content">
         <div id="camera" class="Camera">
-          <canvas id="qr-canvas" class="Camera-display"></canvas>
+          <canvas class="Camera-display"></canvas>
           <div class="CameraRealtime hidden">
             <video class="Camera-video" muted autoplay playsinline></video>
             <div class="Camera-instructions">Point at a QR code</div>

--- a/app/styles/camera.css
+++ b/app/styles/camera.css
@@ -85,6 +85,15 @@ h1, h2, h3, h4, h5 {
   display: none;
 }
 
+.Camera .CameraRealtime {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
 .Camera .CameraRealtime.hidden {
   visibility: hidden;
 }


### PR DESCRIPTION
Hello Paul.
Thanks for your awesome QR Scanner.
As I'm planning to create a Polymer Element based on your qr scanner, I refactored it a little bit to be easier to integrate into a custom element. In that process I also removed some code duplication, unused code and fixed some small bugs (line numbers refer to the current head of the production branch):

- line 33: removed unused variable `detectedQRCode`  / undefined return value
- line 109: removed unused variable `canvas`. Therefore also removed unused `id="qr-canvas"` in the html markup
- line 149: removed unnecessary line `self.qrcodeNavigate = ""`
- line 193-194: removed unused variables `videoRect` and `videoElementScale`
- lines 196-214: refactored the resizing inside of the `loadeddata` event into a `resize` method. The `loadeddata` event on the other hand had been refactored into a `onDimensionsChanged` event. Like this, the method can also be called from outside and is now also triggered on window resize. This fixes a bug, where the video didn't resize on window resize and the visible rect within the cameraOverlay and the rect drawn on the canvas became out of sync.
- line 203-211: Refactored the computation of the `scaleFactor` into `getDimensions` to avoid code duplication between the resizing of the video and the resizing of the canvas image portion in `setupVariables`. Also removed the case distinction between the video being smaller then the screen or bigger to always cover the whole screen with the video which is already archived by `scaleFactor = 1 / Math.min(heightRatio, widthRatio)` in both cases (note that if the video is smaller then the screen in one dimension, then `1 / Math.min(heightRatio, widthRatio)` is greater then 1 and thus the video is scaled up which I think was the desired effect?).
- line 219: the refactoring of the `scaleFactor` computation into the `getDimensions` method
- line 223: If we get no cameras by the `getCameras` method, your code still tries to run a camera but can't switch the camera (line 390) therefore I changed the check to `<=1`.
- line 236-242: removed unused method `toggleFacingState`
- line 255: remove unused parameter `e`
- line 258-268: refactored starting and stopping cameras into methods that can be called from outside. Also replaced line `this.checked === true` by `cameraToggleInput.checked === true` to fix a bug where on `visibilitychange` always the first camera resumed recordning instead of the previously used one.
- line 230,325,533-534: removed the `shouldLayout` flag as it looked like legacy code to me. Correct me if I'm wrong.
- line 308: set the initial value of cameras to `null` to be able to know whether we did not recieve any cameras yet or there are just no cameras.
- line 352: removed unused return value
- line 384: avoid that the same camera is set again for performance and reliability reasons
- line 404: add an additional check before `requestAnimationFrame` whether our camera is actually still running. While also `cancelAnimationFrame` gets called in line 388 this did not always reliably stop the `onframe` events for me.
- line 424: remove a wrong comment
- line 460-461,471-473: removed instance variables `wHeight`, `wWidth`, `scaleX`, `scaleY`, `scaleFactor` as these are just used locally in the `setupVariables` method
- line 464-465,566-567: removed unnecessary variables `dx` and `dy`, which are always 0.
- line 479: removed unused variable `overlayCoords`
- line 474,482,486,490: removed the `coordinatesHaveChanged` flag and don't call `setupVariables` and `drawOverlay` now on every frame anymore but only on resizes or video dimension changes
- line 507: `overlayDimensions` as parameter instead of `width` and `height` to avoid double computation of the dimensions
- line 511-527: remove unused variables `boxHeightSize` and `boxHeightWidth` and setting the attributes on the unused `overlayCoords`. Remove the check for the removed `coordinatesHaveChanged`.
- line 530,536-537: rename `setupVariables` to `resize` which now can also be called from outside. Replace unused parameter `e`. Make all size computations relative to the container of the qr scanner to allow it to be potentially smaller then the full window.
- line 546-556,559: use refactored `scaleFactor` computation instead of code duplication
- line 569-570: remove unnecessary initialization
- line 580: remove unused return value and call `drawOverlay` which is now only called on calls to `resize`.
- line 583-586: call the `resize` method on window resize and video dimensions changed
- line 88-95 in camera.css: overflow:hidden for videos bigger then the container to avoid that the container grows

I hope that some of those changes are useful for you.

Kind regards and thanks,
Daniel