### PR TITLE
Improve feature detection and reuse BarcodeDetector

### DIFF
--- a/app/scripts/qrclient.js
+++ b/app/scripts/qrclient.js
@@ -1,6 +1,41 @@
 import * as Comlink from './comlink.js';
 
-const proxy = Comlink.proxy(new Worker('/scripts/qrworker.js'));
+function getWorkerDetector() {
+  const proxy = Comlink.proxy(new Worker('/scripts/qrworker.js'));
+  return (width, height, imageData) => {
+    return proxy.detectUrl(width, height, imageData);
+  };
+}
+
+async function getNativeDetector() {
+  try {
+    const formats = await BarcodeDetector.getSupportedFormats();
+    if (formats.find(format => format === 'qr_code')) {
+      let detector = new BarcodeDetector({formats: ['qr_code']});
+      return async (width, height, imageData) => {
+        try {
+          const barcodes = await detector.detect(imageData);
+          if (barcodes.length > 0)
+            return barcodes[0].rawValue;
+        } catch (e) {
+          console.log("Error detecting barcode, falling back to polyfill.");
+          detect = getWorkerDetector();
+          return detect(width, height, imageData);
+        }
+      }
+    } else {
+      console.log("QR codes not supported, falling back to polyfill.");
+    }
+  } catch (e) {
+    console.log("Error during feature detection, falling back to polyfill.");
+  }
+  return getWorkerDetector();
+}
+
+let detect = async (width, height, imageData) => {
+  detect = await getNativeDetector();
+  return detect(width, height, imageData);
+}
 
 export const decode = async function (context) {
   try {
@@ -8,7 +43,7 @@ export const decode = async function (context) {
     let width = canvas.width;
     let height = canvas.height;
     let imageData = context.getImageData(0, 0, width, height);
-    return await proxy.detectUrl(width, height, imageData);
+    return await detect(width, height, imageData);
   } catch (err) {
     console.log(err);
   }

--- a/app/scripts/qrworker.js
+++ b/app/scripts/qrworker.js
@@ -1,34 +1,14 @@
 import * as Comlink from './comlink.js';
 import {qrcode} from './qrcode.js';
 
-// Use the native API's
-let nativeDetector = async (width, height, imageData) => {
-  try {
-    let barcodeDetector = new BarcodeDetector();
-    let barcodes = await barcodeDetector.detect(imageData);
-    // return the first barcode.
-    if (barcodes.length > 0) {
-      return barcodes[0].rawValue;
-    }
-  } catch(err) {
-    detector = workerDetector;
-  }
-};
-
 // Use the polyfil
-let workerDetector = async (width, height, imageData) => {
+let detectUrl = async (width, height, imageData) => {
   try {
     return qrcode.decode(width, height, imageData);
   } catch (err) {
-    // the library throws an excpetion when there are no qrcodes.
+    // the library throws an exception when there are no qrcodes.
     return;
   }
-}
-
-let detectUrl = async (width, height, imageData) => {
-  return detector(width, height, imageData);
 };
-
-let detector = ('BarcodeDetector' in self) ? nativeDetector : workerDetector;
 
 Comlink.expose({detectUrl}, self);


### PR DESCRIPTION
This patch includes improved feature detection support to decide whether
or not the polyfill is necessary. It first checks if the BarcodeDetector
supports QR codes and if so creates a new instance configured to only
detect this format. This instance is reused between frames to avoid
repeating the initialization steps.

Usage of the BarcodeDetector object is also moved to the main thread.
While the polyfill is blocking the native implementation is asynchronous
and sending the image data to a worker first is wasted effort.